### PR TITLE
Use Vimeo's "do not track" flag: `&dnt=1`

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,7 +56,7 @@ import prob_0_1_0_8_400 from '~/assets/prob_0-1_0-8_400.png'
   <section class="flex flex-col items-center justify-center p-4">
     <iframe
       title="vimeo-player"
-      src="https://player.vimeo.com/video/806844587?h=7f385a19b3"
+      src="https://player.vimeo.com/video/806844587?h=7f385a19b3&dnt=1"
       width="640"
       height="360"
       class=""


### PR DESCRIPTION
This is one possible - maybe the minimal - solution to 

- #1 

via suggestion number 2 😁 

This stops the tracking cookie, but only by Vimeo's honouring the "do not track" flag. The embedded frame still leaves cookies that are claimed as functional, so @UCL-ISD would need to check they are happy.